### PR TITLE
Avoid overwriting existing solution file

### DIFF
--- a/lib/advent_of_code_cli/commands/scaffold.rb
+++ b/lib/advent_of_code_cli/commands/scaffold.rb
@@ -4,8 +4,11 @@ module AdventOfCode
   module Commands
     class Scaffold < Command
       def execute
-        say("Creating file: #{solution_file_name}...")
-        create_file(solution_file_name, solution_file_contents)
+
+        unless File.exist?(solution_file_name)
+          say("Creating file: #{solution_file_name}...")
+          create_file(solution_file_name, solution_file_contents)
+        end
 
         unless Dir.exist?("inputs")
           say("Creating inputs directory...")


### PR DESCRIPTION
I wrapped the creation of the solution file, in order to avoid overwriting an existing one without asking.

As a second step, the script could ask for confirmation to overwrite the existing file, and only then do that.
