### PR TITLE
Only write input file scaffold, if it doesn’t exist already

### DIFF
--- a/lib/advent_of_code_cli/commands/scaffold.rb
+++ b/lib/advent_of_code_cli/commands/scaffold.rb
@@ -15,7 +15,7 @@ module AdventOfCode
           Dir.mkdir("inputs")
         end
 
-        unless Dir.exist?(input_file_name)
+        unless File.exist?(input_file_name)
           say("Creating file: #{input_file_name}...")
           create_file(input_file_name)
         end

--- a/lib/advent_of_code_cli/commands/scaffold.rb
+++ b/lib/advent_of_code_cli/commands/scaffold.rb
@@ -15,8 +15,10 @@ module AdventOfCode
           Dir.mkdir("inputs")
         end
 
-        say("Creating file: #{input_file_name}...")
-        create_file(input_file_name)
+        unless Dir.exist?(input_file_name)
+          say("Creating file: #{input_file_name}...")
+          create_file(input_file_name)
+        end
 
         unless Dir.exist?("examples")
           say("Creating examples directory...")


### PR DESCRIPTION
I also started to find the overwriting of the input file in the scaffolding code, a bit annoying.
Therefore this pull request. 

(I generally think overwriting existing files without notice should be avoided. Guess how I came to that conclusion. 🙂)
