### PR TITLE
Gracefully rescue NotImplementedError

### DIFF
--- a/lib/advent_of_code_cli/commands/example/solve.rb
+++ b/lib/advent_of_code_cli/commands/example/solve.rb
@@ -51,6 +51,8 @@ module AdventOfCode
           end
 
           say "Took #{end_time - start_time} seconds to solve"
+        rescue NotImplementedError
+          say "Part #{part} has not yet been implemented", :yellow
         end
 
         def expected_answers

--- a/lib/advent_of_code_cli/commands/solve.rb
+++ b/lib/advent_of_code_cli/commands/solve.rb
@@ -33,6 +33,8 @@ module AdventOfCode
 
         say "Part #{part} result: #{result}"
         say "Took #{end_time - start_time} seconds to solve"
+      rescue NotImplementedError
+        say "Part #{part} has not yet been implemented", :yellow
       end
     end
   end


### PR DESCRIPTION
`NotImplementedError`s currently output big ugly backtraces. You should be able to use this CLI while parts of your solution are not yet implemented.