### PR TITLE
Duplicate input before solving

### DIFF
--- a/lib/advent_of_code_cli/commands/solve.rb
+++ b/lib/advent_of_code_cli/commands/solve.rb
@@ -28,7 +28,7 @@ module AdventOfCode
 
       def solution(module_name, part, input)
         start_time = Time.now
-        result = Object.const_get(module_name).send("part_#{part}", input)
+        result = Object.const_get(module_name).send("part_#{part}", input.dup)
         end_time = Time.now
 
         say "Part #{part} result: #{result}"


### PR DESCRIPTION
Duplicate the input before each call to the solver methods `part_one` and `part_two`. This ensures that changes to the input in `part_one` do not affect the value of `input` passed to `part_two`. Since we know that `input` will be an array of strings, a shallow copy is sufficient.